### PR TITLE
added Asset and File options for Image Providers in the package as against having only network image.

### DIFF
--- a/lib/image_stack.dart
+++ b/lib/image_stack.dart
@@ -19,6 +19,7 @@ class ImageStack extends StatelessWidget {
   final int widgetCount;
   final double widgetBorderWidth;
   final Color widgetBorderColor;
+  final List<ImageProvider> providers;
 
   ImageStack({
     Key key,
@@ -35,6 +36,7 @@ class ImageStack extends StatelessWidget {
     ),
     this.backgroundColor = Colors.white,
   })  : children = [],
+        providers = [],
         widgetBorderColor = null,
         widgetBorderWidth = null,
         widgetCount = null,
@@ -60,11 +62,12 @@ class ImageStack extends StatelessWidget {
     ),
     this.backgroundColor = Colors.white,
   })  : imageList = [],
+        providers = [],
         imageBorderColor = null,
         imageBorderWidth = null,
         imageCount = null,
-        imageRadius=null,
-        imageSource=null,
+        imageRadius = null,
+        imageSource = null,
         assert(children != null),
         assert(extraCountTextStyle != null),
         assert(widgetBorderColor != null),
@@ -72,16 +75,45 @@ class ImageStack extends StatelessWidget {
         assert(totalCount != null),
         super(key: key);
 
-
+  ImageStack.providers({
+    Key key,
+    @required this.providers,
+    this.imageRadius = 25,
+    this.imageCount = 3,
+    this.totalCount,
+    this.imageBorderWidth = 2,
+    this.imageBorderColor = Colors.grey,
+    this.extraCountTextStyle = const TextStyle(
+      color: Colors.black,
+      fontWeight: FontWeight.w600,
+    ),
+    this.backgroundColor = Colors.white,
+  })  : imageList = [],
+        children = [],
+        widgetBorderColor = null,
+        widgetBorderWidth = null,
+        widgetCount = null,
+        widgetRadius = null,
+        imageSource = null,
+        assert(providers != null),
+        assert(extraCountTextStyle != null),
+        assert(imageBorderColor != null),
+        assert(backgroundColor != null),
+        assert(totalCount != null),
+        super(key: key);
 
   @override
   Widget build(BuildContext context) {
     var images = List<Widget>();
+    var widgets = List<Widget>();
+    var providersImages = List<Widget>();
     int _size = children.length > 0 ? widgetCount : imageCount;
     if (imageList.isNotEmpty) {
       images.add(circularImage(imageList[0]));
-    } else if(children.isNotEmpty){
-      images.add(circularWidget(children[0]));
+    } else if (children.isNotEmpty) {
+      widgets.add(circularWidget(children[0]));
+    } else if (providers.isNotEmpty) {
+      providersImages.add(circularProviders(providers[0]));
     }
 
     if (imageList.length > 1) {
@@ -105,7 +137,7 @@ class ImageStack extends StatelessWidget {
       if (children.length < _size) {
         _size = children.length;
       }
-      images.addAll(children
+      widgets.addAll(children
           .sublist(1, _size)
           .asMap()
           .map((index, widget) => MapEntry(
@@ -118,14 +150,33 @@ class ImageStack extends StatelessWidget {
           .values
           .toList());
     }
+    if (providers.length > 1) {
+      if (providers.length < _size) {
+        _size = providers.length;
+      }
+      providersImages.addAll(providers
+          .sublist(1, _size)
+          .asMap()
+          .map((index, data) => MapEntry(
+        index,
+        Positioned(
+          right: 0.8 * imageRadius * (index + 1.0),
+          child: circularProviders(data),
+        ),
+      ))
+          .values
+          .toList());
+    }
     return Container(
       child: Row(
         children: <Widget>[
-          images.isNotEmpty
+          images.isNotEmpty || widgets.isNotEmpty || providersImages.isNotEmpty
               ? Stack(
             overflow: Overflow.visible,
             textDirection: TextDirection.rtl,
-            children: images,
+            children: children.length > 0
+                ? widgets
+                : providers.length > 0 ? providersImages : images,
           )
               : SizedBox(),
           Container(
@@ -191,6 +242,30 @@ class ImageStack extends StatelessWidget {
           color: Colors.white,
           image: DecorationImage(
             image: imageProvider(imageUrl),
+            fit: BoxFit.cover,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget circularProviders(ImageProvider imageProvider) {
+    return Container(
+      height: imageRadius,
+      width: imageRadius,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: Colors.white,
+          width: imageBorderWidth,
+        ),
+      ),
+      child: Container(
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: Colors.white,
+          image: DecorationImage(
+            image: imageProvider,
             fit: BoxFit.cover,
           ),
         ),

--- a/lib/image_stack.dart
+++ b/lib/image_stack.dart
@@ -13,6 +13,7 @@ class ImageStack extends StatelessWidget {
   final Color imageBorderColor;
   final TextStyle extraCountTextStyle;
   final Color backgroundColor;
+  final ImageSource imageSource;
 
   ImageStack({
     Key key,
@@ -22,6 +23,7 @@ class ImageStack extends StatelessWidget {
     this.totalCount,
     this.imageBorderWidth = 2,
     this.imageBorderColor = Colors.grey,
+    this.imageSource = ImageSource.Network,
     this.extraCountTextStyle = const TextStyle(
       color: Colors.black,
       fontWeight: FontWeight.w600,
@@ -48,12 +50,12 @@ class ImageStack extends StatelessWidget {
           .sublist(1, _size)
           .asMap()
           .map((index, image) => MapEntry(
-                index,
-                Positioned(
-                  right: 0.8 * imageRadius * (index + 1.0),
-                  child: circularImage(image),
-                ),
-              ))
+        index,
+        Positioned(
+          right: 0.8 * imageRadius * (index + 1.0),
+          child: circularImage(image),
+        ),
+      ))
           .values
           .toList());
     }
@@ -62,31 +64,31 @@ class ImageStack extends StatelessWidget {
         children: <Widget>[
           images.isNotEmpty
               ? Stack(
-                  overflow: Overflow.visible,
-                  textDirection: TextDirection.rtl,
-                  children: images,
-                )
+            overflow: Overflow.visible,
+            textDirection: TextDirection.rtl,
+            children: images,
+          )
               : SizedBox(),
           Container(
             margin: EdgeInsets.only(left: 5),
             child: totalCount - images.length > 0
                 ? Container(
-                    constraints: BoxConstraints(minWidth: imageRadius),
-                    padding: EdgeInsets.all(3),
-                    height: imageRadius,
-                    decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(imageRadius),
-                        border: Border.all(
-                            color: imageBorderColor, width: imageBorderWidth),
-                        color: backgroundColor),
-                    child: Center(
-                      child: Text(
-                        (totalCount - images.length).toString(),
-                        textAlign: TextAlign.center,
-                        style: extraCountTextStyle,
-                      ),
-                    ),
-                  )
+              constraints: BoxConstraints(minWidth: imageRadius),
+              padding: EdgeInsets.all(3),
+              height: imageRadius,
+              decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(imageRadius),
+                  border: Border.all(
+                      color: imageBorderColor, width: imageBorderWidth),
+                  color: backgroundColor),
+              child: Center(
+                child: Text(
+                  (totalCount - images.length).toString(),
+                  textAlign: TextAlign.center,
+                  style: extraCountTextStyle,
+                ),
+              ),
+            )
                 : SizedBox(),
           ),
         ],
@@ -110,11 +112,26 @@ class ImageStack extends StatelessWidget {
           shape: BoxShape.circle,
           color: Colors.white,
           image: DecorationImage(
-            image: NetworkImage(imageUrl),
+            image: imageProvider(imageUrl),
             fit: BoxFit.cover,
           ),
         ),
       ),
     );
   }
+
+  imageProvider(imageUrl) {
+    if(this.imageSource == ImageSource.Asset){
+      return AssetImage(imageUrl);
+    } else if(this.imageSource == ImageSource.File) {
+      return FileImage(imageUrl);
+    }
+    return NetworkImage(imageUrl);
+  }
+}
+
+enum ImageSource {
+  Asset,
+  Network,
+  File
 }

--- a/lib/image_stack.dart
+++ b/lib/image_stack.dart
@@ -20,6 +20,7 @@ class ImageStack extends StatelessWidget {
   final double widgetBorderWidth;
   final Color widgetBorderColor;
   final List<ImageProvider> providers;
+  final bool showTotalCount;
 
   ImageStack({
     Key key,
@@ -30,6 +31,7 @@ class ImageStack extends StatelessWidget {
     this.imageBorderWidth = 2,
     this.imageBorderColor = Colors.grey,
     this.imageSource = ImageSource.Network,
+    this.showTotalCount = true,
     this.extraCountTextStyle = const TextStyle(
       color: Colors.black,
       fontWeight: FontWeight.w600,
@@ -56,6 +58,7 @@ class ImageStack extends StatelessWidget {
     this.totalCount,
     this.widgetBorderWidth = 2,
     this.widgetBorderColor = Colors.grey,
+    this.showTotalCount = true,
     this.extraCountTextStyle = const TextStyle(
       color: Colors.black,
       fontWeight: FontWeight.w600,
@@ -83,6 +86,7 @@ class ImageStack extends StatelessWidget {
     this.totalCount,
     this.imageBorderWidth = 2,
     this.imageBorderColor = Colors.grey,
+    this.showTotalCount = true,
     this.extraCountTextStyle = const TextStyle(
       color: Colors.black,
       fontWeight: FontWeight.w600,
@@ -182,6 +186,7 @@ class ImageStack extends StatelessWidget {
           Container(
             margin: EdgeInsets.only(left: 5),
             child: totalCount - images.length > 0
+                ? showTotalCount
                 ? Container(
               constraints: BoxConstraints(minWidth: imageRadius),
               padding: EdgeInsets.all(3),
@@ -189,7 +194,8 @@ class ImageStack extends StatelessWidget {
               decoration: BoxDecoration(
                   borderRadius: BorderRadius.circular(imageRadius),
                   border: Border.all(
-                      color: imageBorderColor, width: imageBorderWidth),
+                      color: imageBorderColor,
+                      width: imageBorderWidth),
                   color: backgroundColor),
               child: Center(
                 child: Text(
@@ -199,7 +205,8 @@ class ImageStack extends StatelessWidget {
                 ),
               ),
             )
-                : SizedBox(),
+                : SizedBox()
+                : Container(),
           ),
         ],
       ),

--- a/lib/image_stack.dart
+++ b/lib/image_stack.dart
@@ -14,6 +14,11 @@ class ImageStack extends StatelessWidget {
   final TextStyle extraCountTextStyle;
   final Color backgroundColor;
   final ImageSource imageSource;
+  final List<Widget> children;
+  final double widgetRadius;
+  final int widgetCount;
+  final double widgetBorderWidth;
+  final Color widgetBorderColor;
 
   ImageStack({
     Key key,
@@ -29,18 +34,55 @@ class ImageStack extends StatelessWidget {
       fontWeight: FontWeight.w600,
     ),
     this.backgroundColor = Colors.white,
-  })  : assert(imageList != null),
+  })  : children = [],
+        widgetBorderColor = null,
+        widgetBorderWidth = null,
+        widgetCount = null,
+        widgetRadius = null,
+        assert(imageList != null),
         assert(extraCountTextStyle != null),
         assert(imageBorderColor != null),
         assert(backgroundColor != null),
         assert(totalCount != null),
         super(key: key);
 
+  ImageStack.widgets({
+    Key key,
+    @required this.children,
+    this.widgetRadius = 25,
+    this.widgetCount = 3,
+    this.totalCount,
+    this.widgetBorderWidth = 2,
+    this.widgetBorderColor = Colors.grey,
+    this.extraCountTextStyle = const TextStyle(
+      color: Colors.black,
+      fontWeight: FontWeight.w600,
+    ),
+    this.backgroundColor = Colors.white,
+  })  : imageList = [],
+        imageBorderColor = null,
+        imageBorderWidth = null,
+        imageCount = null,
+        imageRadius=null,
+        imageSource=null,
+        assert(children != null),
+        assert(extraCountTextStyle != null),
+        assert(widgetBorderColor != null),
+        assert(backgroundColor != null),
+        assert(totalCount != null),
+        super(key: key);
+
+
+
   @override
   Widget build(BuildContext context) {
     var images = List<Widget>();
-    int _size = imageCount;
-    if (imageList.isNotEmpty) images.add(circularImage(imageList[0]));
+    int _size = children.length > 0 ? widgetCount : imageCount;
+    if (imageList.isNotEmpty) {
+      images.add(circularImage(imageList[0]));
+    } else if(children.isNotEmpty){
+      images.add(circularWidget(children[0]));
+    }
 
     if (imageList.length > 1) {
       if (imageList.length < _size) {
@@ -54,6 +96,23 @@ class ImageStack extends StatelessWidget {
         Positioned(
           right: 0.8 * imageRadius * (index + 1.0),
           child: circularImage(image),
+        ),
+      ))
+          .values
+          .toList());
+    }
+    if (children.length > 1) {
+      if (children.length < _size) {
+        _size = children.length;
+      }
+      images.addAll(children
+          .sublist(1, _size)
+          .asMap()
+          .map((index, widget) => MapEntry(
+        index,
+        Positioned(
+          right: 0.8 * widgetRadius * (index + 1.0),
+          child: circularWidget(widget),
         ),
       ))
           .values
@@ -96,6 +155,25 @@ class ImageStack extends StatelessWidget {
     );
   }
 
+  circularWidget(Widget widget) {
+    return Container(
+      height: widgetRadius,
+      width: widgetRadius,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: backgroundColor,
+        border: Border.all(
+          color: widgetBorderColor,
+          width: widgetBorderWidth,
+        ),
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(widgetRadius),
+        child: widget,
+      ),
+    );
+  }
+
   Widget circularImage(String imageUrl) {
     return Container(
       height: imageRadius,
@@ -121,17 +199,13 @@ class ImageStack extends StatelessWidget {
   }
 
   imageProvider(imageUrl) {
-    if(this.imageSource == ImageSource.Asset){
+    if (this.imageSource == ImageSource.Asset) {
       return AssetImage(imageUrl);
-    } else if(this.imageSource == ImageSource.File) {
+    } else if (this.imageSource == ImageSource.File) {
       return FileImage(imageUrl);
     }
     return NetworkImage(imageUrl);
   }
 }
 
-enum ImageSource {
-  Asset,
-  Network,
-  File
-}
+enum ImageSource { Asset, Network, File }


### PR DESCRIPTION
You have a great package, I tried using it and discovered it only works with network images, so I have implemented asset and file image provider to the package here's an example.

```
ImageStack(
       imageList: [
             'assets/images/user.jpg',
             'assets/images/user.jpg',
              'assets/images/user.jpg',
              'assets/images/user.jpg',
              'assets/images/user.jpg',
            ],
       imageSource: ImageSource.Asset,
       totalCount: 5,
       imageRadius: 30, // Radius of each images
       imageCount: 5, // Maximum number of images to be shown in stack
       imageBorderWidth: 3, // Border width around the images
 )
```

ALSO

Based on this issue https://github.com/karan413255/image_stack/issues/1

I have implement `ImageStack.widgets` and `ImageStack.providers`.

This will enable users place custom widgets and ImageProviders. Look Below to see code samples.

```
ImageStack.widgets(
         children: <Widget>[
              Center(child: Text('1'), ),
              Center(child: Text('1'),),
              Center(child: Text('1'),),
              Center(child: Text('1') ),
              Center(child: Text('1'),),
           ],
           backgroundColor: Colors.black54,
           totalCount: 5,
           widgetRadius: 30, // Radius of each images
           widgetCount: 5, // Maximum number of images to be shown in stack
           widgetBorderWidth: 2,
           widgetBorderColor: Colors.black,// Border width around the images
    )
```

```
ImageStack.providers(
     providers: [
     AssetImage('assets/images/user.jpg'),
     AssetImage('assets/images/user.jpg'),
     FileImage(file.path),
      NetwordImage('http://place.com/assets/images/user.jpg'),
  ],
   backgroundColor: Colors.black54,
     totalCount: 4,
     imageRadius: 30, // Radius of each images
      imageCount: 4, // Maximum number of images to be shown in stack
     imageBorderWidth: 2,
    imageBorderColor: Colors.black,// Border width around the images
 );
```